### PR TITLE
Add ZEIP-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@
 | [On-chain order generation by smart contracts](https://github.com/0xProject/ZEIPs/issues/7)                                 | 7      | 2.0.0            |
 | [Atomic order matching](https://github.com/0xProject/ZEIPs/issues/2)                                                        | 2      | 2.0.0            |
 | [Off-chain order generation by smart contracts](https://github.com/0xProject/ZEIPs/issues/1)                                | 1      | 2.0.0            |
+| [Arbitrary fee tokens](https://github.com/0xProject/ZEIPs/issues/28)                                                        | 28     | 3.0.0            |

--- a/ZEIPS/ZEIP-28.md
+++ b/ZEIPS/ZEIP-28.md
@@ -1,0 +1,37 @@
+## Preamble
+
+    ZEIP: 28
+    Title: Arbitrary Fee Tokens
+    Author: @PhABC, 0x Core Team
+    Type: Standard Track
+    Category: Core
+    Status: Final
+    Created: 2019-03-8
+
+Discussion: #28
+
+## Simple Summary
+
+Allow taker and maker fees to be paid in any asset, not only ZRX.
+
+## Abstract
+
+Add two new asset data fields to the order schema so maker and taker fees can be paid in arbitrary assets.
+
+## Motivation
+
+Currently, most relayers take their fee via a spread instead of accepting fees paid in ZRX. The main reasons for this are better UX, lower cost and because relayers and users do not want to transact using ZRX. This ZEIP proposes to allow maker and taker fees to be paid in any asset, not only ZRX.
+
+This also allows all relayers, not just matching relayers to take percentage fees.
+
+## Specification
+
+Add two new fields to the order schema:
+- `makerFeeAssetData`: The fee asset to be paid by the maker on fill.
+- `takerFeeAssetData`: The fee asset to be paid by the taker on fill.
+
+In `_settleOrder()` and `_settleMatchedOrders()`, transfer maker and taker fees to the fee recipients *after* transfering maker and taker assets (in case the main assets would help cover the fees).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Preamble

    ZEIP: 28
    Title: Arbitrary Fee Tokens
    Author: @PhABC, 0x Core Team
    Type: Standard Track
    Category: Core
    Status: Final
    Created: 2019-03-8

Discussion: #28

## Simple Summary

Allow taker and maker fees to be paid in any asset, not only ZRX.

## Abstract

Add two new asset data fields to the order schema so maker and taker fees can be paid in arbitrary assets.

## Motivation

Currently, most relayers take their fee via a spread instead of accepting fees paid in ZRX. The main reasons for this are better UX, lower cost and because relayers and users do not want to transact using ZRX. This ZEIP proposes to allow maker and taker fees to be paid in any asset, not only ZRX.

This also allows all relayers, not just matching relayers to take percentage fees.

## Specification

Add two new fields to the order schema:
- `makerFeeAssetData`: The fee asset to be paid by the maker on fill.
- `takerFeeAssetData`: The fee asset to be paid by the taker on fill.

In `_settleOrder()` and `_settleMatchedOrders()`, transfer maker and taker fees to the fee recipients *after* transfering maker and taker assets (in case the main assets would help cover the fees).

## Copyright

Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
